### PR TITLE
error: 'GPIO_PIN_INTR_NEGEDGE' undeclared (first use in this function); did you mean 'GPIO_INTR_NEGEDGE'?

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-set(COMPONENT_SRCS
-    "src/ads1115.c")
-set(COMPONENT_ADD_INCLUDEDIRS "include")
-
-register_component()
+idf_component_register(
+  SRCS "src/ads1115.c"
+  INCLUDE_DIRS "include"
+  PRIV_REQUIRES driver
+)

--- a/include/ads1115.h
+++ b/include/ads1115.h
@@ -71,7 +71,7 @@ typedef union { // configuration register
 typedef struct {
   bool in_use; // gpio is used
   gpio_num_t pin; // ready pin
-  xQueueHandle gpio_evt_queue; // pin triggered queue
+  QueueHandle_t gpio_evt_queue; // pin triggered queue
 } ads1115_rdy_pin_t;
 
 typedef struct {

--- a/src/ads1115.c
+++ b/src/ads1115.c
@@ -85,7 +85,7 @@ void ads1115_set_rdy_pin(ads1115_t* ads, gpio_num_t gpio) {
   gpio_config_t io_conf;
   esp_err_t err;
 
-  io_conf.intr_type = GPIO_PIN_INTR_NEGEDGE; // positive to negative (pulled down)
+  io_conf.intr_type = GPIO_INTR_NEGEDGE; // positive to negative (pulled down)
   io_conf.pin_bit_mask = 1<<gpio;
   io_conf.mode = GPIO_MODE_INPUT;
   io_conf.pull_up_en = 1;

--- a/src/ads1115.c
+++ b/src/ads1115.c
@@ -7,7 +7,7 @@
 
 static void IRAM_ATTR gpio_isr_handler(void* arg) {
   const bool ret = 1; // dummy value to pass to queue
-  xQueueHandle gpio_evt_queue = (xQueueHandle) arg; // find which queue to write
+  QueueHandle_t gpio_evt_queue = (QueueHandle_t) arg; // find which queue to write
   xQueueSendFromISR(gpio_evt_queue, &ret, NULL);
 }
 


### PR DESCRIPTION
Hiya!

Thanks a ton for this repo! It looks like an enum variant has been renamed on the latest master branch, so I figured I'd open a PR fixing things so that they compile.

With that being said, I probably wouldn't merge this until that version is stabilized. I'm just leaving this here so others can see it (if they have the same issue) and so it can be eventually merged :)

Hope you are well!